### PR TITLE
Add endpoint logging to server response

### DIFF
--- a/lib/request-helper.js
+++ b/lib/request-helper.js
@@ -4,7 +4,7 @@ const request = require('then-request');
 const log = require('debug')('macpaw:qa-api-services');
 
 module.exports = {
-  isSuccess(statusCode) {
+  isStatusCodeOk(statusCode) {
     const regExp = new RegExp('^20[0-9]$');
 
     return regExp.test(statusCode);
@@ -19,24 +19,36 @@ module.exports = {
   async sendRequest(method, url, options) {
     log(`Executing '${method}: ${url}' with options: %O`, options);
     const response = await request(method, url, options);
-    log(`Server responded with status code: '${response.statusCode}' and body: ${response.body.toString()}'`);
 
     return response;
   },
 
   getResponseBody(response) {
-    this.catchError(response);
     const body = response.body.toString();
 
     return body ? JSON.parse(body) : {};
   },
 
-  catchError(response) {
-    const {statusCode} = response;
+  handleResponse(response) {
+    const {
+      url,
+      statusCode,
+      body,
+    } = response;
 
-    if (!this.isSuccess(statusCode)) {
-      const body = response.body.toString();
-      throw new Error(`Oops, the server responded with status code: '${statusCode}' and body: ${body}`);
+    if (!this.isStatusCodeOk(statusCode)) {
+      throw new Error(
+        `Oops!
+        Endpoint '${url}' responded with
+        status code: '${statusCode}'
+        body: ${body.toString()}`,
+      );
     }
+
+    log(
+      `Endpoint '${url}' responded with
+      status code: '${statusCode}'
+      and body: %O`, this.getResponseBody(response),
+    );
   },
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -9,30 +9,35 @@ module.exports = {
 
   get(url, options) {
     const response = this.browser.call(() => requestHelper.sendRequest('GET', url, options));
+    requestHelper.handleResponse(response);
 
     return requestHelper.getResponseBody(response);
   },
 
   post(url, options) {
     const response = this.browser.call(() => requestHelper.sendRequest('POST', url, options));
+    requestHelper.handleResponse(response);
 
     return requestHelper.getResponseBody(response);
   },
 
   patch(url, options) {
     const response = this.browser.call(() => requestHelper.sendRequest('PATCH', url, options));
+    requestHelper.handleResponse(response);
 
     return requestHelper.getResponseBody(response);
   },
 
   put(url, options) {
     const response = this.browser.call(() => requestHelper.sendRequest('PUT', url, options));
+    requestHelper.handleResponse(response);
 
     return requestHelper.getResponseBody(response);
   },
 
   del(url, options) {
     const response = this.browser.call(() => requestHelper.sendRequest('DELETE', url, options));
+    requestHelper.handleResponse(response);
 
     return requestHelper.getResponseBody(response);
   },


### PR DESCRIPTION
# Features

## For now, we don't know about the server URL which returns status code NOT Ok:
- Allure reporter:
<img width="750" alt="Screenshot 2021-05-17 at 10 21 58" src="https://user-images.githubusercontent.com/963502/118450158-90115180-b6fc-11eb-8a5c-aa20f8247a4d.png">
- DEBUG mode in command line:
<img width="1597" alt="Screenshot 2021-05-17 at 10 21 29" src="https://user-images.githubusercontent.com/963502/118450248-aa4b2f80-b6fc-11eb-9cbe-c831f8a7e3f5.png">

## The new solutions will be:
- Allure reporter:
<img width="846" alt="Screenshot 2021-05-17 at 09 56 32" src="https://user-images.githubusercontent.com/963502/118450373-ccdd4880-b6fc-11eb-8a83-05f6de3bbd76.png">
- DEBUG mode in command line:
<img width="1115" alt="Screenshot 2021-05-17 at 09 59 43" src="https://user-images.githubusercontent.com/963502/118450455-e1b9dc00-b6fc-11eb-96fb-bd764ad0c618.png">
